### PR TITLE
lizard: always assign outputSize when extracting data

### DIFF
--- a/src/LzArchive.c
+++ b/src/LzArchive.c
@@ -200,10 +200,11 @@ int LzArchive_ExtractData(LzArchive* ctx, int index, const char* filename, uint8
 	status = LzMapRes(SzArEx_Extract(db, &ctx->dataStream.s, index, &blockIndex,
 		&buffer, outputSize, &offset, &processedSize, &ctx->allocator, &ctx->allocator));
 
+	*outputSize = processedSize;
+
 	if (offset == 0)
 	{
 		*outputData = buffer;
-		*outputSize = processedSize;
 	}
 	else
 	{


### PR DESCRIPTION
We need to always assign `outputSize`, otherwise we can accidentally return the size of the whole block instead of just the file we extracted.

Slipped past me because I was using the size obtained from `LzArchive_GetFileSize`