### PR TITLE
WAYK-1552 Fix an out-of-bounds read in SzReadAndDecodePackedStreams

### DIFF
--- a/fuzzing/FuzzLizard.cpp
+++ b/fuzzing/FuzzLizard.cpp
@@ -1,3 +1,8 @@
+/*
+ * Recommended command-line:
+ *  ASAN_OPTIONS="allocator_may_return_null=1" ./fuzzing/FuzzLizard -detect_leaks=0 corpus/
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <assert.h>

--- a/src/lzma/7zMemInStream.c
+++ b/src/lzma/7zMemInStream.c
@@ -64,9 +64,21 @@ static SRes MemInStream_Seek(const ILookInStream *pp, Int64 *pos, ESzSeek origin
   CMemInStream *p = (CMemInStream *)pp;
   switch (origin)
   {
-    case SZ_SEEK_SET: p->pos = p->begin + *pos; break;
-    case SZ_SEEK_CUR: p->pos += *pos; break;
-    case SZ_SEEK_END: p->pos = p->end + *pos; break;
+    case SZ_SEEK_SET: 
+      if (p->begin + *pos > p->end)
+        return SZ_ERROR_FAIL;
+      p->pos = p->begin + *pos;
+      break;
+    case SZ_SEEK_CUR:
+      if (p->pos + *pos > p->end)
+        return SZ_ERROR_FAIL;  
+      p->pos += *pos;
+      break;
+    case SZ_SEEK_END: 
+      if (p->end + *pos > p->end)
+        return SZ_ERROR_FAIL;
+      p->pos = p->end + *pos;
+      break;
     default: return 1;
   }
 


### PR DESCRIPTION
The function MemInStream_Seek could seek past the end of the input buffer, which would cause an out-of-bounds read later in SzReadAndDecodePackedStreams.